### PR TITLE
docs: add badges for Docs, version, jsDelivr, and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ _One hub to manage every release_
 </div>
 
 [![CI](https://github.com/teneplaysofficial/release-hub/actions/workflows/ci.yml/badge.svg)](https://github.com/teneplaysofficial/release-hub)
+[![Docs](https://img.shields.io/badge/Docs-available-brightgreen?logo=readthedocs)](https://teneplaysofficial.github.io/release-hub)
+[![release-hub version](https://img.shields.io/github/v/release/teneplaysofficial/release-hub?include_prereleases&sort=semver&color=brightgreen&logo=semver&label=Version)](https://github.com/teneplaysofficial/release-hub/releases)
+[![jsDelivr hits](https://img.shields.io/jsdelivr/npm/hm/release-hub?color=brightgreen&logo=jsdelivr&label=jsDelivr)](https://www.jsdelivr.com/package/npm/release-hub)
+[![License](https://img.shields.io/github/license/teneplaysofficial/release-hub?color=brightgreen&logo=spdx&label=LICENSE)](https://github.com/teneplaysofficial/release-hub/blob/main/LICENSE)
 
 ## Overview
 


### PR DESCRIPTION
Added additional badges for documentation, version, jsDelivr hits, and license information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added four new informational badges to the project README displaying direct links to documentation resources, the current software release version, live package download statistics from jsDelivr, and complete project license information. These improvements enhance overall project visibility and provide users with convenient access to important project metadata and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->