### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pages-ci.yml
+++ b/.github/workflows/pages-ci.yml
@@ -1,5 +1,8 @@
 name: Pages CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ['main']


### PR DESCRIPTION
Potential fix for [https://github.com/teneplaysofficial/release-hub/security/code-scanning/2](https://github.com/teneplaysofficial/release-hub/security/code-scanning/2)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions used by this workflow. Since the job only checks out code and runs a local Jekyll build, it only needs read access to repository contents.

The best fix is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs in this workflow. Set it to `contents: read`, which allows `actions/checkout` to function while preventing write operations via `GITHUB_TOKEN`. No job appears to need broader permissions (no pushes, releases, PR updates, etc.), so this should not change existing behavior.

Concretely:
- Edit `.github/workflows/pages-ci.yml`.
- Insert the block:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name: Pages CI` line and before the `on:` block.
- No additional imports, methods, or definitions are needed; this is entirely a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
